### PR TITLE
Context propagation API

### DIFF
--- a/context.go
+++ b/context.go
@@ -1,0 +1,49 @@
+package di
+
+import "context"
+
+// Context describe DI context propagator capabilities
+type Context interface {
+	Put(Container) Context
+	Container() Container
+	Resolver() Resolver
+	Raw() context.Context
+}
+
+// Ctx returns context propagator
+func Ctx(c context.Context) Context {
+	return &ctx{
+		ctx: c,
+	}
+}
+
+const contextKey = "di.ctx"
+
+type ctx struct {
+	ctx context.Context
+}
+
+// Put sets container in context
+func (self *ctx) Put(c Container) Context {
+	self.ctx = context.WithValue(self.ctx, contextKey, c)
+	return self
+}
+
+// Container returns container from context or creates a new one
+func (self *ctx) Container() Container {
+	if c, has := self.ctx.Value(contextKey).(Container); has {
+		return c
+	}
+
+	return NewContainer()
+}
+
+// Resolver returns a resolver instance against a Container() output
+func (self *ctx) Resolver() Resolver {
+	return NewResolver(self.Container())
+}
+
+// Raw returns raw context.Context
+func (self *ctx) Raw() context.Context {
+	return self.ctx
+}

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,56 @@
+package di_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/HnH/di"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestContextSuite(t *testing.T) {
+	suite.Run(t, new(ContextSuite))
+}
+
+type ContextSuite struct {
+	context di.Context
+
+	suite.Suite
+}
+
+func (suite *ContextSuite) SetupSuite() {
+	suite.context = di.Ctx(context.Background()).Put(di.NewContainer())
+}
+
+func (suite *ContextSuite) TearDownTest() {
+	suite.context.Container().Reset()
+}
+
+func (suite *ContextSuite) TestPut() {
+	var ctx = context.Background()
+	suite.Require().NotNil(di.Ctx(ctx).Put(di.NewContainer()))
+}
+
+func (suite *ContextSuite) TestDefaultContainer() {
+	var (
+		container = di.Ctx(context.Background()).Container()
+		shape     Shape
+	)
+
+	suite.Require().EqualError(di.NewResolver(container).Resolve(&shape), "di: no binding found for: di_test.Shape")
+}
+
+func (suite *ContextSuite) TestResolve() {
+	suite.Require().NoError(suite.context.Container().Singleton(newCircle))
+
+	var shape Shape
+	suite.Require().NoError(suite.context.Resolver().Resolve(&shape))
+	suite.Require().IsType(&Circle{}, shape)
+
+	suite.context.Container().Reset()
+	suite.Require().EqualError(suite.context.Resolver().Resolve(&shape), "di: no binding found for: di_test.Shape")
+}
+
+func (suite *ContextSuite) TestRaw() {
+	suite.Require().NotNil(suite.context.Raw())
+}


### PR DESCRIPTION
```go
type Context interface {
    Put(Container) Context
    Container() Container
    Resolver() Resolver
    Raw() context.Context
}
```
Context propagation is possible via `di.Context` abstraction. Quick example:
```go
var container = di.NewContainer()
container.Implementation(newCircle())

var (
    ctx = di.Ctx(context.Background).Put(container)
    shp Shape
)

err = ctx.Resolver().Resolve(&shp) // err == nil
```