### PR TITLE
Fill() can fill inner structs recursively

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,9 +160,12 @@ err = di.Singleton(func() (Database, Database) {
 }, di.WithName("data", "cache"))
 
 type App struct {
-    mailer Mailer    `di:"type"`
-    data   Database  `di:"name"`
+    mailer Mailer    `di:"type"` // fills by field type (Mailer)
+    data   Database  `di:"name"` // fills by field type (Mailer) and requires binding name to be field name (data)
     cache  Database  `di:"name"`
+    inner  struct {
+        cache Database `di:"name"`	
+    } `di:"recursive"`           // instructs DI to fill struct recursively
     x int
 }
 
@@ -175,6 +178,7 @@ err = container.Fill(&myApp)
 // [Named Bindings]
 // `App.data` will be a MySQL implementation of the Database interface
 // `App.cache` will be a Redis implementation of the Database interface
+// `App.inner.cache` will be a Redis implementation of the Database interface
 
 // `App.x` will be ignored since it has no `di` tag
 ```

--- a/README.md
+++ b/README.md
@@ -160,13 +160,15 @@ err = di.Singleton(func() (Database, Database) {
 }, di.WithName("data", "cache"))
 
 type App struct {
-    mailer Mailer    `di:"type"` // fills by field type (Mailer)
-    data   Database  `di:"name"` // fills by field type (Mailer) and requires binding name to be field name (data)
-    cache  Database  `di:"name"`
-    inner  struct {
+    mailer  Mailer     `di:"type"` // fills by field type (Mailer)
+    data    Database   `di:"name"` // fills by field type (Mailer) and requires binding name to be field name (data)
+    cache   Database   `di:"name"`
+    inner   struct {
         cache Database `di:"name"`	
-    } `di:"recursive"`           // instructs DI to fill struct recursively
-    x int
+    } `di:"recursive"`             // instructs DI to fill struct recursively
+    another struct {
+        cache Database `di:"name"` // won't have any affect as long as outer field in App struct won't have `di:"recursive"` tag
+    }
 }
 
 var App = App{}
@@ -180,7 +182,7 @@ err = container.Fill(&myApp)
 // `App.cache` will be a Redis implementation of the Database interface
 // `App.inner.cache` will be a Redis implementation of the Database interface
 
-// `App.x` will be ignored since it has no `di` tag
+// `App.another` will be ignored since it has no `di` tag
 ```
 
 Alternatively map[string]Type or []Type can be provided. It will be filled with all available implementations of provided Type.

--- a/context.go
+++ b/context.go
@@ -30,14 +30,14 @@ type ctx struct {
 }
 
 // SetContainer puts container to a context
-func (ct *ctx) SetContainer(c Container) Context {
-	ct.Context = context.WithValue(ct.Context, ctxKeyContainer, c)
-	return ct
+func (self *ctx) SetContainer(c Container) Context {
+	self.Context = context.WithValue(self.Context, ctxKeyContainer, c)
+	return self
 }
 
 // Container returns container from context or returns a global container
-func (ct *ctx) Container() Container {
-	if c, has := ct.Context.Value(ctxKeyContainer).(Container); has {
+func (self *ctx) Container() Container {
+	if c, has := self.Context.Value(ctxKeyContainer).(Container); has {
 		return c
 	}
 
@@ -45,21 +45,21 @@ func (ct *ctx) Container() Container {
 }
 
 // SetResolver puts container to a context
-func (ct *ctx) SetResolver(r Resolver) Context {
-	ct.Context = context.WithValue(ct.Context, ctxKeyResolver, r)
-	return ct
+func (self *ctx) SetResolver(r Resolver) Context {
+	self.Context = context.WithValue(self.Context, ctxKeyResolver, r)
+	return self
 }
 
 // Resolver returns a resolver instance either preset or against a Container() output
-func (ct *ctx) Resolver() Resolver {
-	if r, has := ct.Context.Value(ctxKeyResolver).(Resolver); has {
+func (self *ctx) Resolver() Resolver {
+	if r, has := self.Context.Value(ctxKeyResolver).(Resolver); has {
 		return r
 	}
 
-	return NewResolver(ct.Container())
+	return NewResolver(self.Container())
 }
 
 // Raw returns raw context.Context
-func (ct *ctx) Raw() context.Context {
-	return ct.Context
+func (self *ctx) Raw() context.Context {
+	return self.Context
 }

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -183,9 +183,15 @@ func (suite *ResolverSuite) TestFillStruct() {
 		S Shape    `di:"type"`
 		D Database `di:"type"`
 		R Shape    `di:"name"`
+		U *struct {
+			U Shape `di:"type"`
+		} `di:"recursive"`
 		X string
 		y int
 	}{
+		U: &struct {
+			U Shape `di:"type"`
+		}{},
 		X: "dummy string",
 		y: 100,
 	}
@@ -195,6 +201,7 @@ func (suite *ResolverSuite) TestFillStruct() {
 	suite.Require().IsType(&Circle{}, target.S)
 	suite.Require().IsType(&MySQL{}, target.D)
 	suite.Require().IsType(&Rectangle{}, target.R)
+	suite.Require().IsType(&Circle{}, target.U.U)
 	suite.Require().Equal(target.X, "dummy string")
 	suite.Require().Equal(target.y, 100)
 }
@@ -267,6 +274,15 @@ func (suite *ResolverSuite) TestFillInvalidTag() {
 	}{}
 
 	suite.Require().EqualError(suite.resolver.Fill(&target), `di: S has an invalid struct tag: filling *struct { S di_test.Shape "di:\"invalid\"" }`)
+}
+
+func (suite *ResolverSuite) TestFillInvalidRecursive() {
+	suite.Require().NoError(suite.container.Singleton(newRectangle, di.WithName("R")))
+	var target = struct {
+		R Rectangle `di:"recursive"`
+	}{}
+
+	suite.Require().EqualError(suite.resolver.Fill(&target), `di: receiver is not a pointer: struct: filling *struct { R di_test.Rectangle "di:\"recursive\"" }`)
 }
 
 func (suite *ResolverSuite) TestFillSliceUnbound() {


### PR DESCRIPTION
```go
err = di.Singleton(func() (Database, Database) {
    return &MySQL{}, &Redis{} 
}, di.WithName("data", "cache"))

type App struct {
    inner  struct {
        cache Database `di:"name"`	
    } `di:"recursive"` // will be filled recursively
    another struct {
        cache Database `di:"name"`	
    } // will be ignored
}

var App = App{}
err = container.Fill(&myApp)

// `App.inner.cache` will be a Redis implementation of the Database interface
// `App.another` will be ignored since it has no `di` tag
```
