### PR TITLE
Resolver: fill struct fields of type struct with recursive

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -263,6 +263,11 @@ func (self *resolver) fillStruct(receiver interface{}) error {
 
 		case "recursive":
 			var ptr = reflect.NewAt(elem.Field(i).Type(), unsafe.Pointer(elem.Field(i).UnsafeAddr())).Elem()
+
+			if ptr.Kind() == reflect.Slice || ptr.Kind() == reflect.Map {
+				ptr = ptr.Addr()
+			}
+
 			if err := self.Fill(ptr.Interface()); err != nil {
 				return err
 			}

--- a/resolver.go
+++ b/resolver.go
@@ -264,7 +264,8 @@ func (self *resolver) fillStruct(receiver interface{}) error {
 		case "recursive":
 			var ptr = reflect.NewAt(elem.Field(i).Type(), unsafe.Pointer(elem.Field(i).UnsafeAddr())).Elem()
 
-			if ptr.Kind() == reflect.Slice || ptr.Kind() == reflect.Map {
+			switch ptr.Kind() {
+			case reflect.Slice, reflect.Map, reflect.Struct:
 				ptr = ptr.Addr()
 			}
 

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -263,6 +263,42 @@ func (suite *ResolverSuite) TestFillMap() {
 	suite.Require().IsType(&Rectangle{}, shapes["square"])
 }
 
+func (suite *ResolverSuite) TestFillStructWithSliceMap() {
+	suite.Require().NoError(suite.container.Singleton(newCircle, di.WithName("circle")))
+	suite.Require().NoError(suite.container.Singleton(newRectangle, di.WithName("square")))
+
+	var shapes struct {
+		list []Shape          `di:"recursive"`
+		dict map[string]Shape `di:"recursive"`
+	}
+
+	suite.Require().NoError(suite.resolver.Fill(&shapes))
+	suite.Require().Equal(2, len(shapes.list))
+	suite.Require().Equal(2, len(shapes.dict))
+
+	var list = map[string]struct{}{
+		reflect.TypeOf(shapes.list[0]).Elem().Name(): {},
+		reflect.TypeOf(shapes.list[1]).Elem().Name(): {},
+	}
+
+	_, ok := list["Circle"]
+	suite.Require().True(ok)
+
+	_, ok = list["Rectangle"]
+	suite.Require().True(ok)
+
+	var dict = map[string]struct{}{
+		reflect.TypeOf(shapes.dict["circle"]).Elem().Name(): {},
+		reflect.TypeOf(shapes.dict["square"]).Elem().Name(): {},
+	}
+
+	_, ok = dict["Circle"]
+	suite.Require().True(ok)
+
+	_, ok = dict["Rectangle"]
+	suite.Require().True(ok)
+}
+
 func (suite *ResolverSuite) TestFillReceiverInvalid() {
 	var target = 0
 	suite.Require().EqualError(suite.resolver.Fill(&target), "di: invalid receiver: *int: filling *int")

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -332,13 +332,16 @@ func (suite *ResolverSuite) TestFillInvalidTag() {
 	suite.Require().EqualError(suite.resolver.Fill(&target), `di: S has an invalid struct tag: filling *struct { S di_test.Shape "di:\"invalid\"" }`)
 }
 
-func (suite *ResolverSuite) TestFillInvalidRecursive() {
-	suite.Require().NoError(suite.container.Singleton(newRectangle, di.WithName("R")))
+func (suite *ResolverSuite) TestFillRecursiveStruct() {
+	suite.Require().NoError(suite.container.Singleton(newRectangle))
 	var target = struct {
-		R Rectangle `di:"recursive"`
+		inner struct {
+			S Shape `di:"type"`
+		} `di:"recursive"`
 	}{}
 
-	suite.Require().EqualError(suite.resolver.Fill(&target), `di: receiver is not a pointer: struct: filling *struct { R di_test.Rectangle "di:\"recursive\"" }`)
+	suite.Require().NoError(suite.resolver.Fill(&target))
+	suite.Require().Equal(newRectangle().GetArea(), target.inner.S.GetArea())
 }
 
 func (suite *ResolverSuite) TestFillSliceUnbound() {


### PR DESCRIPTION
Example:
```golang
var target struct {
  inner struct {
    S Shape `di:"type"`
  } `di:"recursive"`
}
```