### PR TITLE
Fix context

### DIFF
--- a/container.go
+++ b/container.go
@@ -165,8 +165,8 @@ func (self *container) Factory(constructor any, opts ...Option) error {
 
 // Implementation receives ready instance and binds it to its REAL type, which means that declared abstract variable type (interface) is ignored
 func (self *container) Implementation(implementation any, opts ...Option) error {
-	self.lock.RLock()
-	defer self.lock.RUnlock()
+	self.lock.Lock()
+	defer self.lock.Unlock()
 
 	var ref = reflect.TypeOf(implementation)
 	if _, ok := self.bindings[ref]; !ok {

--- a/context.go
+++ b/context.go
@@ -57,7 +57,7 @@ func (self *ctx) SetResolver(r Resolver) Context {
 // Resolver returns a resolver instance either preset or against a Container() output
 func (self *ctx) Resolver() Resolver {
 	if r, has := self.Context.Value(ctxKeyResolver).(Resolver); has {
-		return r
+		return r.With(self.Context)
 	}
 
 	return NewResolver(self.Container())


### PR DESCRIPTION
там в одном месте запись в мапу без write лока, поправил. Воспроизвел когда 100500 раз автотесты запустил
```sh
fatal error: fatal error: concurrent map writes
concurrent map writes
pgw/mono/kernel/entrypoints/www/processing.(*service).Handler.LoggerMiddleware.func5.1({0x1670b38, 0xc000414ed0}, {0x166eb50, 0xc000476540}, 0xc0002617c0, {0x1345160, 0xc000536e60})
        /home/alexeysergey/processing-hub/kernel/entrypoints/www/base/middleware.go:111 +0x243

```