### PR TITLE
Fix data-race

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -5,8 +5,11 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"sync"
 	"unsafe"
 )
+
+var globalMutext = sync.Mutex{}
 
 // NewResolver constructs a Resolver against one or more Containers
 func NewResolver(containers ...Container) Resolver {
@@ -243,6 +246,8 @@ func (self *resolver) Fill(receiver any) (err error) {
 }
 
 func (self *resolver) fillStruct(receiver any) error {
+	globalMutext.Lock()
+	defer globalMutext.Unlock()
 	var elem = reflect.ValueOf(receiver).Elem()
 	for i := 0; i < elem.NumField(); i++ {
 		var tag, ok = elem.Type().Field(i).Tag.Lookup("di")


### PR DESCRIPTION
```go
WARNING: DATA RACE
Write at 0x00c000539a30 by goroutine 173:
  reflect.typedmemmove()
      /usr/lib/go/src/runtime/mbarrier.go:213 +0x0
  reflect.Value.Set()
      /usr/lib/go/src/reflect/value.go:2062 +0x184
  github.com/HnH/di.(*resolver).fillStruct()
      /home/alexey/go/pkg/mod/github.com/!hn!h/di@v1.3.1/resolver.go:292 +0x4be
  github.com/HnH/di.(*resolver).Fill()
      /home/alexey/go/pkg/mod/github.com/!hn!h/di@v1.3.1/resolver.go:226 +0x316
```